### PR TITLE
Bugfix/call with no grads

### DIFF
--- a/dadaptation/dadapt_adagrad.py
+++ b/dadaptation/dadapt_adagrad.py
@@ -30,7 +30,7 @@ class DAdaptAdaGrad(torch.optim.Optimizer):
         weight_decay (float): 
             Weight decay, i.e. a L2 penalty (default: 0).
         eps (float): 
-            Term added to the denominator outside of the root operation to improve numerical stability. (default: 0).
+            Term added to the denominator outside of the root operation to improve numerical stability. (default: 1e-6).
         d0 (float):
             Initial D estimate for D-adaptation (default 1e-6). Rarely needs changing.
         growth_rate (float):
@@ -47,11 +47,14 @@ class DAdaptAdaGrad(torch.optim.Optimizer):
         eps: float = 0.0,
         d0 = 1e-6, growth_rate=float('inf')
     ):
+        if d0 <= 0:
+            raise ValueError("Invalid d0 value: {}".format(d0))
         if lr <= 0:
             raise ValueError(f"Learning rate {lr} must be positive")
         if momentum < 0:
             raise ValueError(f"Momentum {momentum} must be non-negative")
-
+        if eps <= 0:
+            raise ValueError("Invalid epsilon value: {}".format(eps))
 
         defaults = dict(lr=lr, 
             momentum=momentum,

--- a/dadaptation/dadapt_adagrad.py
+++ b/dadaptation/dadapt_adagrad.py
@@ -192,6 +192,11 @@ class DAdaptAdaGrad(torch.optim.Optimizer):
         sksq_weighted = sksq_weighted + sksq_weighted_change
         skl1 = skl1 + skl1_change
 
+        # if we have not done any progres, return
+        # if we have any gradients available, will have skl1 > 0 (unless \|g\|=0)
+        if skl1 == 0:
+            return loss
+
         gsq_weighted = gsq_weighted + dlr*dlr*g_sq
         d_hat = d
         

--- a/dadaptation/dadapt_adam.py
+++ b/dadaptation/dadapt_adam.py
@@ -37,7 +37,7 @@ class DAdaptAdam(torch.optim.Optimizer):
         momentum (float): 
             Momentum value in  the range [0,1) (default: 0.9).
         eps (float): 
-            Term added to the denominator outside of the root operation to improve numerical stability. (default: 0).
+            Term added to the denominator outside of the root operation to improve numerical stability. (default: 1e-8).
         weight_decay (float): 
             Weight decay, i.e. a L2 penalty (default: 0).
         log_every (int): 
@@ -56,9 +56,11 @@ class DAdaptAdam(torch.optim.Optimizer):
                  weight_decay=0, log_every=0,
                  decouple=False,
                  d0=1e-6, growth_rate=float('inf')):
-        if not 0.0 <= lr:
+        if not 0.0 < d0:
+            raise ValueError("Invalid d0 value: {}".format(d0))
+        if not 0.0 < lr:
             raise ValueError("Invalid learning rate: {}".format(lr))
-        if not 0.0 <= eps:
+        if not 0.0 < eps:
             raise ValueError("Invalid epsilon value: {}".format(eps))
         if not 0.0 <= betas[0] < 1.0:
             raise ValueError("Invalid beta parameter at index 0: {}".format(betas[0]))

--- a/dadaptation/dadapt_adam.py
+++ b/dadaptation/dadapt_adam.py
@@ -70,7 +70,6 @@ class DAdaptAdam(torch.optim.Optimizer):
         if decouple:
             print(f"Using decoupled weight decay")
 
-        
         defaults = dict(lr=lr, betas=betas, eps=eps,
                         weight_decay=weight_decay,
                         d = d0, 
@@ -166,6 +165,11 @@ class DAdaptAdam(torch.optim.Optimizer):
 
         gsq_weighted = beta2*gsq_weighted + g_sq*(dlr**2)*(1-beta2)
         d_hat = d
+
+        # if we have not done any progres, return
+        # if we have any gradients available, will have sk_l1 > 0 (unless \|g\|=0)
+        if sk_l1 == 0:
+            return loss
 
         if lr > 0.0:
             d_hat = (sksq_weighted/(1-beta2) - gsq_weighted)/sk_l1

--- a/dadaptation/dadapt_sgd.py
+++ b/dadaptation/dadapt_sgd.py
@@ -95,6 +95,10 @@ class DAdaptSGD(torch.optim.Optimizer):
 
                 g_sq += (grad * grad).sum().item()
 
+        # if we have not done any updates
+        # if we have any gradients available, will have g_sq > 0 (unless \|g\|=0)
+        if g_sq == 0:
+            return loss
 
         group = self.param_groups[0]
         if k == 0: 

--- a/dadaptation/dadapt_sgd.py
+++ b/dadaptation/dadapt_sgd.py
@@ -38,6 +38,12 @@ class DAdaptSGD(torch.optim.Optimizer):
         weight_decay=0, 
         log_every=0,
         d0=1e-6, growth_rate=float('inf')):
+
+        if not 0.0 < d0:
+            raise ValueError("Invalid d0 value: {}".format(d0))
+        if not 0.0 < lr:
+            raise ValueError("Invalid learning rate: {}".format(lr))
+
         defaults = dict(lr=lr,
             momentum=momentum, 
             weight_decay=weight_decay, k=0,
@@ -68,7 +74,6 @@ class DAdaptSGD(torch.optim.Optimizer):
         gsq_weighted = group['gsq_weighted']
         growth_rate = group['growth_rate']
         d = group['d']
-        
 
         g_sq = 0.0
         sk_sq = 0.0

--- a/dadaptation/experimental/dadapt_adam_ip.py
+++ b/dadaptation/experimental/dadapt_adam_ip.py
@@ -162,6 +162,11 @@ class DAdaptAdamIP(torch.optim.Optimizer):
 
         numerator_weighted = beta2*numerator_weighted + (1-beta2)*numerator_acum
         d_hat = d
+
+        # if we have not done any progres, return
+        # if we have any gradients available, will have sk_l1 > 0 (unless \|g\|=0)
+        if sk_l1 == 0:
+            return loss
         
         if lr > 0.0:
             d_hat = 2*(beta2/(1-beta2))*numerator_weighted/sk_l1

--- a/dadaptation/experimental/dadapt_adam_ip.py
+++ b/dadaptation/experimental/dadapt_adam_ip.py
@@ -56,9 +56,11 @@ class DAdaptAdamIP(torch.optim.Optimizer):
                  weight_decay=0, log_every=0,
                  decouple=False,
                  d0=1e-6, growth_rate=float('inf')):
-        if not 0.0 <= lr:
+        if not 0.0 < d0:
+            raise ValueError("Invalid d0 value: {}".format(d0))
+        if not 0.0 < lr:
             raise ValueError("Invalid learning rate: {}".format(lr))
-        if not 0.0 <= eps:
+        if not 0.0 < eps:
             raise ValueError("Invalid epsilon value: {}".format(eps))
         if not 0.0 <= betas[0] < 1.0:
             raise ValueError("Invalid beta parameter at index 0: {}".format(betas[0]))

--- a/dadaptation/experimental/dadapt_sgd_ip.py
+++ b/dadaptation/experimental/dadapt_sgd_ip.py
@@ -40,6 +40,12 @@ class DAdaptSGDIP(torch.optim.Optimizer):
         weight_decay=0, 
         log_every=0,
         d0=1e-6, growth_rate=float('inf')):
+
+        if not 0.0 < d0:
+            raise ValueError("Invalid d0 value: {}".format(d0))
+        if not 0.0 < lr:
+            raise ValueError("Invalid learning rate: {}".format(lr))
+
         defaults = dict(lr=lr,
             momentum=momentum, 
             weight_decay=weight_decay, k=0,

--- a/dadaptation/experimental/dadapt_sgd_ip.py
+++ b/dadaptation/experimental/dadapt_sgd_ip.py
@@ -137,6 +137,11 @@ class DAdaptSGDIP(torch.optim.Optimizer):
         numerator_weighted += numerator_acum
         d_hat = d
 
+        # if we have not done any updates
+        # if we have any gradients available, will have sk_sq > 0 (unless \|g\|=0)
+        if sk_sq == 0:
+            return loss
+
         if lr > 0.0:
             d_hat = 2*numerator_weighted/math.sqrt(sk_sq)
             d = group['d'] = max(d, min(d_hat, d*growth_rate))


### PR DESCRIPTION
Hi!

Thank you very much for the paper and the code! Really interesting work! I have used the optimizer in several of my experiments and got very good results!

I use D-adaptaion's adam. However, I cannot use it with Horovod, which is the library I use for distributed Deep Learning training.

I debugged the code a bit and I think I found the problem. Horovod calls the `step` method initially before computing any gradients.
The problem is that in the code for DAdaptAdam's `step` method, variables `g_sq`, `sksq_weighted`, and `sk_l1` are initially set to zero. Then, it goes over the gradients and since non are present, these variables never get updated. However, in line 162, we have `d_hat = (sksq_weighted/(1-beta2) - gsq_weighted)/sk_l1`, which gets executed regardless of whether we have had any gradients or not (i.e. these variables are updated or not). In this case, `sksq_weighted` and `sk_l1` are 0 (because no gradients) and `gsq_weighted` is 0 too (because no gradient and also it is the first time we are calling `step()`). Thus, it is `0/0` which raises error. 

Also, when there is no gradient, on lines 169 and 197, we update `gsq_weighted` and `k`, which I dont know if it is the desired action.

In this pull request I did the following:
- put a guard in all class initializers for `d0 > 0`, `lr > 0`, because if they are `=0`, we have no progress for `s` and also check `eps > 0`, having it `=0` may causes instability.
- figured out a way to skip the method `step` when no gradients are available.

For the second one, in, for example, DAdaptAdam, I return prematurely when `sk_l1` is zero. This covers the case of not having any gradient but also returns when the function starts at the best location (`x_0 =x*`), which is a very rare situation---when `x_0 \neq x*`, then `s_k \neq 0` and `sk_l1` asymptotically goes to zero, so not a problem. However, when this happens, the change causes the code to not update `k` and "skip" that step; thus calling it without any gradients is not considered a "step" toward logging the gradients.
In the rest of the classes, I check for something similar.
What I check are not the direct variables for when the gradients are available but they indirectly are and help us know when we do not have any gradients and should not update our parameters such as `s`.

I tested this implementation and it works fine like previous version with the correct gradients. It also works in distributed mode as checked with Horovod.

Thank you again!
And please let me know if there was anything I could do regarding this PR.