### PR TITLE
SGD default momentum is 0

### DIFF
--- a/dadaptation/dadapt_sgd.py
+++ b/dadaptation/dadapt_sgd.py
@@ -22,7 +22,7 @@ class DAdaptSGD(torch.optim.Optimizer):
         betas (Tuple[float, float], optional): coefficients used for computing
             running averages of gradient and its square (default: (0.9, 0.999))
         momentum (float): 
-            Momentum value in  the range [0,1) (default: 0.9).
+            Momentum value in  the range [0,1) (default: 0).
         weight_decay (float): 
             Weight decay, i.e. a L2 penalty (default: 0).
         log_every (int): 


### PR DESCRIPTION
In the code it defaults to 0 in the class `__init__`.