### PR TITLE
Small bug fix: change default eps in DAdaptAdaGrad to avoid value error

### DIFF
--- a/dadaptation/dadapt_adagrad.py
+++ b/dadaptation/dadapt_adagrad.py
@@ -50,7 +50,7 @@ class DAdaptAdaGrad(torch.optim.Optimizer):
         momentum: float = 0, 
         log_every: int = 0,
         weight_decay: float = 0.0,
-        eps: float = 0.0,
+        eps: float = 1e-6,
         d0 = 1e-6, growth_rate=float('inf')
     ):
         if d0 <= 0:


### PR DESCRIPTION
The default value of `eps=0.0` in DAdaptAdaGrad directly raises a value error. I changed it to `eps=1e-6` as specified in the doc string. Thank you for the nice optimizers!